### PR TITLE
Spawned xclip and scrot threads using async

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ awesomewm-screenshot
 ====================
 
 A screenshot widget for Awesome WM.
-It's compatible with Awesome 4
+It's compatible with Awesome 4 (4.3)
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 awesomewm-screenshot
-=======
+====================
 
 A screenshot widget for Awesome WM.
 It's compatible with Awesome 4
@@ -9,7 +9,6 @@ Requirements
 
 * scrot
 * xclip
-
 
 Get it
 ------
@@ -40,9 +39,13 @@ local screenshot = require("screenshot")
           {description = "Take a screenshot of delay", group = "screenshot"}),
 ```
 
-the default storage of the ~/Pictures/
+the default storage of the ~/Pictures/Screenshots/
+
+## This Fork
+
+I added the async functionality in the spawn commands since the orginal way wasn't working for me.
 
 License
-------
+-------
 
 this software is distributed in MIT License

--- a/screenshot.lua
+++ b/screenshot.lua
@@ -2,38 +2,46 @@ local awful = require("awful")
 local naughty = require("naughty")
 
 Timers = { 5, 10 }
-Date = os.date("%Y-%m-%d_%H:%M:%S")                                 --Change File Format Here
-Screenshot = os.getenv("HOME") .. "/Pictures/Screenshots/" .. Date  --Change Directory Here
+
+function getPath()
+    Date = os.date("%Y-%m-%d_%H:%M:%S")                            --Change File Format Here
+    Screenshot = os.getenv("HOME") .. "/Pictures/Screenshots/" .. Date --Change Directory Here
+    return Screenshot
+end
 
 function scrot_full()
-  
+    path=getPath()
     awful.spawn.easy_async_with_shell("scrot " .. Screenshot,
-    function() awful.spawn.easy_async_with_shell("xclip -selection clipboard -t image/png -i " .. Screenshot,
-            scrot_callback("Take a screenshot entire screen")) end)
+        function()
+            awful.spawn.easy_async_with_shell("xclip -selection clipboard -t image/png -i " .. path,
+                scrot_callback("Take a screenshot entire screen"))
+        end)
 end
 
 function scrot_selection()
-   
-    awful.spawn.easy_async_with_shell("scrot -s " .. Screenshot,
-        function() awful.spawn.easy_async_with_shell("xclip -selection clipboard -t image/png -i " .. Screenshot,
-                scrot_callback("Take a screenshot of selection")) end)
-
-  
+    path=getPath()
+    awful.spawn.easy_async_with_shell("scrot -s " .. path,
+        function()
+            awful.spawn.easy_async_with_shell("xclip -selection clipboard -t image/png -i " .. path,
+                scrot_callback("Take a screenshot of selection"))
+        end)
 end
 
 function scrot_window()
-  
-    awful.spawn.easy_async_with_shell("scrot -u " .. Screenshot,
-    function() awful.spawn.easy_async_with_shell("xclip -selection clipboard -t image/png -i " .. Screenshot,
-            scrot_callback("Take a screenshot of focused window")) end)
-
+    path=getPath()
+    awful.spawn.easy_async_with_shell("scrot -u " .. path,
+        function()
+            awful.spawn.easy_async_with_shell("xclip -selection clipboard -t image/png -i " .. path,
+                scrot_callback("Take a screenshot of focused window"))
+        end)
 end
 
 function scrot_delay()
+    path=getPath()
     items = {}
     for key, value in ipairs(Timers) do
         items[#items + 1] = { tostring(value),
-            "scrot -d " .. value .. " " .. Screenshot .. " -e 'xclip -selection c -t image/png < $f'",
+            "scrot -d " .. value .. " " .. path .. " -e 'xclip -selection c -t image/png < $f'",
             "Take a screenshot of delay" }
     end
     awful.menu.new(
@@ -55,5 +63,3 @@ function scrot_callback(text)
         timeout = 1
     })
 end
-
-

--- a/screenshot.lua
+++ b/screenshot.lua
@@ -1,41 +1,59 @@
 local awful = require("awful")
 local naughty = require("naughty")
 
-timers = { 5,10 }
-screenshot = os.getenv("HOME") .. "/Pictures/scrot/$(date +%F_%T).png"
+Timers = { 5, 10 }
+Date = os.date("%Y-%m-%d_%H:%M:%S")                                 --Change File Format Here
+Screenshot = os.getenv("HOME") .. "/Pictures/Screenshots/" .. Date  --Change Directory Here
 
 function scrot_full()
-    scrot("scrot " .. screenshot .. " -e 'xclip -selection c -t image/png < $f', scrot_callback", scrot_callback, "Take a screenshot of entire screen")
+  
+    awful.spawn.easy_async_with_shell("scrot " .. Screenshot,
+    function() awful.spawn.easy_async_with_shell("xclip -selection clipboard -t image/png -i " .. Screenshot,
+            scrot_callback("Take a screenshot entire screen")) end)
 end
 
 function scrot_selection()
-    scrot("sleep 0.5 && scrot -s " .. screenshot .. " -e 'xclip -selection c -t image/png < $f'", scrot_callback, "Take a screenshot of selection")
+   
+    awful.spawn.easy_async_with_shell("scrot -s " .. Screenshot,
+        function() awful.spawn.easy_async_with_shell("xclip -selection clipboard -t image/png -i " .. Screenshot,
+                scrot_callback("Take a screenshot of selection")) end)
+
+  
 end
 
 function scrot_window()
-    scrot("scrot -u " .. screenshot .. " -e 'xclip -selection c -t image/png < $f'", scrot_callback, "Take a screenshot of focused window")    
+  
+    awful.spawn.easy_async_with_shell("scrot -u " .. Screenshot,
+    function() awful.spawn.easy_async_with_shell("xclip -selection clipboard -t image/png -i " .. Screenshot,
+            scrot_callback("Take a screenshot of focused window")) end)
+
 end
 
 function scrot_delay()
-    items={}
-    for key, value in ipairs(timers)  do
-        items[#items+1]={tostring(value) , "scrot -d ".. value.." " .. screenshot .. " -e 'xclip -selection c -t image/png < $f'","Take a screenshot of delay" }
+    items = {}
+    for key, value in ipairs(Timers) do
+        items[#items + 1] = { tostring(value),
+            "scrot -d " .. value .. " " .. Screenshot .. " -e 'xclip -selection c -t image/png < $f'",
+            "Take a screenshot of delay" }
     end
     awful.menu.new(
-    {
-        items = items
-    }
-    ):show({keygrabber= true})
+        {
+            items = items
+        }
+    ):show({ keygrabber = true })
     scrot_callback()
 end
 
-function scrot(cmd , callback, args)
+function scrot(cmd, callback, args)
     awful.util.spawn_with_shell(cmd)
     callback(args)
 end
+
 function scrot_callback(text)
     naughty.notify({
         text = text,
-        timeout = 0.5
+        timeout = 1
     })
 end
+
+


### PR DESCRIPTION
This may be callback hell. 

Instead of using the && operator to spawn the xclip command after the scrot command I now use the async method to call the xclip command after the scrot command. For some reason the original command was not working for me so modified the code as explained above.